### PR TITLE
Bugfix: emote check

### DIFF
--- a/src/Discord.Addons.Paginator/PaginationService.cs
+++ b/src/Discord.Addons.Paginator/PaginationService.cs
@@ -52,10 +52,13 @@ namespace Discord.Addons.Paginator
                 var _ = Task.Delay(paginated.Options.Timeout).ContinueWith(async _t =>
                 {
                     if (!_messages.ContainsKey(message.Id)) return;
-                    if (paginated.Options.TimeoutAction == StopAction.DeleteMessage)
-                        await message.DeleteAsync();
-                    else if (paginated.Options.TimeoutAction == StopAction.ClearReactions)
-                        await message.RemoveAllReactionsAsync();
+                    if (await channel.GetMessageAsync(message.Id) != null)
+                    {
+                        if (paginated.Options.TimeoutAction == StopAction.DeleteMessage)
+                            await message.DeleteAsync();
+                        else if (paginated.Options.TimeoutAction == StopAction.ClearReactions)
+                            await message.RemoveAllReactionsAsync();
+                    }
                     _messages.Remove(message.Id);
                 });
             }
@@ -87,7 +90,7 @@ namespace Discord.Addons.Paginator
                 }
                 await message.RemoveReactionAsync(reaction.Emote, reaction.User.Value);
                 await WriteLog(Log.Debug($"Handled reaction {reaction.Emote} from user {reaction.UserId}"));
-                if (reaction.Emote.Name == page.Options.EmoteFirst.Name)
+                if (CompareIEmotes(reaction.Emote, page.Options.EmoteFirst))
                 {
                     if (page.CurrentPage != 1)
                     {
@@ -95,7 +98,7 @@ namespace Discord.Addons.Paginator
                         await message.ModifyAsync(x => x.Embed = page.GetEmbed());
                     }
                 }
-                else if (reaction.Emote.Name == page.Options.EmoteBack.Name)
+                else if (CompareIEmotes(reaction.Emote, page.Options.EmoteBack))
                 {
                     if (page.CurrentPage != 1)
                     {
@@ -103,7 +106,7 @@ namespace Discord.Addons.Paginator
                         await message.ModifyAsync(x => x.Embed = page.GetEmbed());
                     }
                 }
-                else if (reaction.Emote.Name == page.Options.EmoteNext.Name)
+                else if (CompareIEmotes(reaction.Emote, page.Options.EmoteNext))
                 {
                     if (page.CurrentPage != page.Count)
                     {
@@ -111,7 +114,7 @@ namespace Discord.Addons.Paginator
                         await message.ModifyAsync(x => x.Embed = page.GetEmbed());
                     }
                 }
-                else if (reaction.Emote.Name == page.Options.EmoteLast.Name)
+                else if (CompareIEmotes(reaction.Emote, page.Options.EmoteLast))
                 {
                     if (page.CurrentPage != page.Count)
                     {
@@ -119,7 +122,7 @@ namespace Discord.Addons.Paginator
                         await message.ModifyAsync(x => x.Embed = page.GetEmbed());
                     }
                 }
-                else if (reaction.Emote.Name == page.Options.EmoteStop.Name)
+                else if (CompareIEmotes(reaction.Emote, page.Options.EmoteStop))
                 {
                     if (page.Options.EmoteStopAction == StopAction.DeleteMessage)
                         await message.DeleteAsync();
@@ -129,7 +132,16 @@ namespace Discord.Addons.Paginator
                 }
             }
         }
-    }
+
+        internal bool CompareIEmotes(IEmote first, IEmote second)
+        {
+            if (first is Emoji emojiFirst && second is Emoji emojiSecond)
+                return emojiFirst.Name == emojiSecond.Name;
+            if (first is Emote emoteFirst && second is Emote emoteSecond)
+                return emoteFirst.Id == emoteSecond.Id;
+            return false;
+        }
+}
 
     public class PaginatedMessage
     {

--- a/src/Discord.Addons.Paginator/PaginationService.cs
+++ b/src/Discord.Addons.Paginator/PaginationService.cs
@@ -52,13 +52,10 @@ namespace Discord.Addons.Paginator
                 var _ = Task.Delay(paginated.Options.Timeout).ContinueWith(async _t =>
                 {
                     if (!_messages.ContainsKey(message.Id)) return;
-                    if (await channel.GetMessageAsync(message.Id) != null)
-                    {
-                        if (paginated.Options.TimeoutAction == StopAction.DeleteMessage)
-                            await message.DeleteAsync();
-                        else if (paginated.Options.TimeoutAction == StopAction.ClearReactions)
-                            await message.RemoveAllReactionsAsync();
-                    }
+                    if (paginated.Options.TimeoutAction == StopAction.DeleteMessage)
+                        await message.DeleteAsync();
+                    else if (paginated.Options.TimeoutAction == StopAction.ClearReactions)
+                        await message.RemoveAllReactionsAsync();
                     _messages.Remove(message.Id);
                 });
             }


### PR DESCRIPTION
Correctly check if its the same emoji (Name for Emotes could mismatch) and if the message still exists (so it doesn't throw a 404 if it tries to modify/delete a non-existing message).

I'm wondering if it would be needed to try/catch inside the delay to avoid this kind of situation:
Someone deletes the paged message at the same time I try to GetMessageAsync (so it's still in the cache), but when I try to modify/delete it, it's not there anymore, throwing a 404.