### PR TITLE
PaginatedMessage(IEnumerable<string> pages,...) is unusable

### DIFF
--- a/src/Discord.Addons.Paginator/PaginationService.cs
+++ b/src/Discord.Addons.Paginator/PaginationService.cs
@@ -134,7 +134,9 @@ namespace Discord.Addons.Paginator
     public class PaginatedMessage
     {
         public PaginatedMessage(IEnumerable<string> pages, string title = "", Color? embedColor = null, IUser user = null, AppearanceOptions options = null)
-            => new PaginatedMessage(pages.Select(x => new Page { Description = x }), title, embedColor, user, options);
+            : this(pages.Select(x => new Page { Description = x }), title, embedColor, user, options)
+        {
+        }
         public PaginatedMessage(IEnumerable<Page> pages, string title = "", Color? embedColor = null, IUser user = null, AppearanceOptions options = null)
         {
             var embeds = new List<Embed>();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3085008/27760596-238d28ea-5e22-11e7-8698-63d33cd13b6e.png)

Using the first ctor (`IEnumerable<string>`), Pages is null, so GetEmbed is throwing a NullRef.
Because it's probably creating a new PaginatedMessage but it's not related with the current one (so all properties are null).