### PR TITLE
Bugfix: HttpException 403

### DIFF
--- a/src/Discord.Addons.Paginator/PaginationService.cs
+++ b/src/Discord.Addons.Paginator/PaginationService.cs
@@ -85,7 +85,6 @@ namespace Discord.Addons.Paginator
                     var _ = message.RemoveReactionAsync(reaction.Emote, reaction.User.Value);
                     return;
                 }
-                await message.RemoveReactionAsync(reaction.Emote, reaction.User.Value);
                 await WriteLog(Log.Debug($"Handled reaction {reaction.Emote} from user {reaction.UserId}"));
                 if (reaction.Emote.Name == page.Options.EmoteFirst.Name)
                 {
@@ -127,6 +126,7 @@ namespace Discord.Addons.Paginator
                         await message.RemoveAllReactionsAsync();
                     _messages.Remove(message.Id);
                 }
+                await message.RemoveReactionAsync(reaction.Emote, reaction.User.Value);
             }
         }
     }

--- a/src/Discord.Addons.Paginator/PaginationService.cs
+++ b/src/Discord.Addons.Paginator/PaginationService.cs
@@ -52,11 +52,11 @@ namespace Discord.Addons.Paginator
                 var _ = Task.Delay(paginated.Options.Timeout).ContinueWith(async _t =>
                 {
                     if (!_messages.ContainsKey(message.Id)) return;
+                    _messages.Remove(message.Id);
                     if (paginated.Options.TimeoutAction == StopAction.DeleteMessage)
                         await message.DeleteAsync();
                     else if (paginated.Options.TimeoutAction == StopAction.ClearReactions)
                         await message.RemoveAllReactionsAsync();
-                    _messages.Remove(message.Id);
                 });
             }
 
@@ -120,11 +120,11 @@ namespace Discord.Addons.Paginator
                 }
                 else if (reaction.Emote.Name == page.Options.EmoteStop.Name)
                 {
+                    _messages.Remove(message.Id);
                     if (page.Options.EmoteStopAction == StopAction.DeleteMessage)
                         await message.DeleteAsync();
                     else if (page.Options.EmoteStopAction == StopAction.ClearReactions)
                         await message.RemoveAllReactionsAsync();
-                    _messages.Remove(message.Id);
                 }
                 await message.RemoveReactionAsync(reaction.Emote, reaction.User.Value);
             }


### PR DESCRIPTION
RemoveReactionAsync will throw an exception when the bot doesn't have permission to remove reactions, so it will stop executing and the paginator won't work.
If we left him at the end, the exception won't stop anything.

Other possible actions:
1) try/catch only it
2) not await it